### PR TITLE
DOC - Enhancements to Sphinx documentation

### DIFF
--- a/.github/workflows/preview_docs.yml
+++ b/.github/workflows/preview_docs.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "readthedocs-preview"
+          project-slug: "google-grain"
           single-version: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,40 +1,46 @@
 # Grain - Feeding JAX Models
 
-
-
 Grain is a library for reading data for training and evaluating JAX models. It's
 open source, fast and deterministic.
 
-::::{grid} 1 2 2 3 :gutter: 1 1 1 2
+::::{grid} 1 2 2 3
+:gutter: 1 1 1 2
 
-:::{grid-item-card} {octicon}`zap;1.5em;sd-mr-1` Powerful Users can bring
-arbitrary Python transformations. :::
+:::{grid-item-card} {octicon}`zap;1.5em;sd-mr-1` Powerful
+Users can bring arbitrary Python transformations.
+:::
 
-:::{grid-item-card} {octicon}`tools;1.5em;sd-mr-1` Flexible Grain is designed to
+:::{grid-item-card} {octicon}`tools;1.5em;sd-mr-1` Flexible
+Grain is designed to
 be modular. Users can readily override Grain components if need be with their
-own implementation. :::
+own implementation.
+:::
 
-:::{grid-item-card} {octicon}`versions;1.5em;sd-mr-1` Deterministic Multiple
-runs of the same pipeline will produce the same output. :::
+:::{grid-item-card} {octicon}`versions;1.5em;sd-mr-1` Deterministic
+Multiple runs of the same pipeline will produce the same output.
+:::
 
-:::{grid-item-card} {octicon}`check-circle;1.5em;sd-mr-1` Resilient to
-pre-emptions Grain is designed such that checkpoints have minimal size. After
+:::{grid-item-card} {octicon}`check-circle;1.5em;sd-mr-1` Resilient to pre-emptions
+Grain is designed such that checkpoints have minimal size. After
 pre-emption, Grain can resume from where it left off and produce the same output
-as if it was never pre-empted. :::
+as if it was never pre-empted.
+:::
 
-:::{grid-item-card} {octicon}`sparkles-fill;1.5em;sd-mr-1` Performant We took
-care while designing Grain to ensure that it's performant (refer to the
+:::{grid-item-card} {octicon}`zap;1.5em;sd-mr-1` Performant
+We took care while designing Grain to ensure that it's performant (refer to the
 [Behind the Scenes](behind_the_scenes.md) section of the documentation.) We also
-tested it against multiple data modalities (e.g.Text/Audio/Images/Videos). :::
+tested it against multiple data modalities (e.g.Text/Audio/Images/Videos).
+:::
 
 :::{grid-item-card} {octicon}`package;1.5em;sd-mr-1` With minimal dependencies
 Grain minimizes its set of dependencies when possible. For example, it should
-not depend on TensorFlow. :::
-
+not depend on TensorFlow.
+:::
 ::::
 
 ``` {toctree}
 :maxdepth: 1
+:hidden:
 :caption: Getting started
 installation
 behind_the_scenes
@@ -43,6 +49,7 @@ data_sources
 
 ``` {toctree}
 :maxdepth: 1
+:hidden:
 :caption: Data Loader
 data_loader/samplers
 data_loader/transformations
@@ -50,20 +57,22 @@ data_loader/transformations
 
 ``` {toctree}
 :maxdepth: 1
+:hidden:
 :caption: Tutorials
 tutorials/dataset_basic_tutorial
 ```
 
-``` {toctree}
-:maxdepth: 1
-:caption: Contributor guides
-CONTRIBUTING
-```
-
 <!-- Automatically generated documentation from docstrings -->
-
 ``` {toctree}
 :maxdepth: 1
+:hidden:
 :caption: References
 autoapi/index
+```
+
+``` {toctree}
+:maxdepth: 1
+:hidden:
+:caption: Contributor guides
+CONTRIBUTING
 ```


### PR DESCRIPTION
This PR;

- Fixes the `index.md` syntax so that the grid is visible; when this was ported, some linter/formatter might have messed up with the markdown syntax. Is there a way to skip this document or markdown files in `/docs`, and we can format those via pre-commit? Otherwise, this might continue to cause issues with myst/rst formatting in the long run
- Hides in-page table of contents
- I also changed the slug in the PR action to `google-grain,` but I am unsure if this is correct (need @iindyk to confirm).
- Remove `private_members` from autoapi

<!-- readthedocs-preview readthedocs-preview start -->
----
📚 Documentation preview 📚: https://google-grain--648.org.readthedocs.build/

<!-- readthedocs-preview readthedocs-preview end -->