### PR TITLE
Fixed an error in the Range Data Source example code

### DIFF
--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -36,7 +36,10 @@ online rather than read records from storage.)
 
 ```python
 range_data_source = grain.python.RangeDataSource(start=1,stop=10,step=2)
-print(list(x)) # prints [1, 3, 5, 7, 9]
+array_list = list()
+for index in range(len(range_data_source)):
+  array_list.append(range_data_source[index])
+print(array_list) # prints [1, 3, 5, 7, 9]
 ```
 
 ### ArrayRecord Data Source


### PR DESCRIPTION
Made correction to the Range DataSource example code in the data_sources.md file to print exactly [1, 3, 5, 7, 9]

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--817.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->