### PR TITLE
Nightly builds

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -49,4 +49,24 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: built-grain-wheels-${{ matrix.os }}-${{ matrix.python-version }}
-          path: /tmp/grain/all_dist/**/*.whl
+          path: /tmp/grain/all_dist/*.whl
+
+  publish-wheel:
+    runs-on: ubuntu-22.04
+    needs: build-and-test
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/grain
+    steps:
+      - name: Download Grain artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: built-grain-wheels-*
+          path: /tmp/grain/all_dist
+          merge-multiple: true
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: /tmp/grain/all_dist

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -45,6 +45,9 @@ jobs:
           export RUN_TESTS=${{ inputs.run_tests }}
           . "${SOURCE_DIR}"'/grain/oss/runner_common.sh'
           build_and_test_grain
+      - name: Remove unaudited wheels
+        if: runner.os == 'Linux'
+        run: find /tmp/grain/all_dist/ -maxdepth 1 -type f | grep -v "manylinux" | xargs rm -v
       - name: Upload Grain artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_and_publish_template.yml
+++ b/.github/workflows/build_and_publish_template.yml
@@ -5,12 +5,16 @@
 name: Build & Publish
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
+      pypi_project_url:
+        required: true
+        type: string
       run_tests:
-        description: 'Run unit tests'
-        required: false
-        default: true
+        required: true
+        type: boolean
+      is_nightly:
+        required: true
         type: boolean
 
 permissions:
@@ -43,6 +47,7 @@ jobs:
           export OUTPUT_DIR="/tmp/grain"
           export SOURCE_DIR="/tmp/grain"
           export RUN_TESTS=${{ inputs.run_tests }}
+          export IS_NIGHTLY=${{ inputs.is_nightly }}
           . "${SOURCE_DIR}"'/grain/oss/runner_common.sh'
           build_and_test_grain
       - name: Remove unaudited wheels
@@ -61,7 +66,7 @@ jobs:
       id-token: write
     environment:
       name: pypi
-      url: https://pypi.org/project/grain
+      url: ${{ inputs.pypi_project_url }}
     steps:
       - name: Download Grain artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish_nightly.yml
+++ b/.github/workflows/publish_nightly.yml
@@ -1,0 +1,14 @@
+name: Build and Publish Nightly
+
+on:
+  schedule:
+    # At 04:00 on Monday.
+    - cron: '0 4 * * 1'
+
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/build_and_publish_template.yml
+    with:
+      pypi_project_url: https://pypi.org/project/grain-nightly
+      run_tests: true
+      is_nightly: true

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,18 @@
+name: Build and Publish Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_tests:
+        description: 'Run unit tests'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/build_and_publish_template.yml
+    with:
+      pypi_project_url: https://pypi.org/project/grain
+      run_tests: ${{ inputs.run_tests }}
+      is_nightly: false

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ __pypackages__/
 
 # Environments
 .venv
+
+# Bazel outputs
+bazel-bin/
+bazel-grain/
+bazel-out/
+bazel-testlogs/

--- a/grain/oss/build_whl.sh
+++ b/grain/oss/build_whl.sh
@@ -72,11 +72,15 @@ main() {
   previous_wd="$(pwd)"
   cd "${TMPDIR}"
   printf '%s : "=== Building wheel\n' "$(date)"
-  if [ "$(uname)" = "Darwin" ]; then
-    "$PYTHON_BIN" setup.py bdist_wheel --python-tag py3"${PYTHON_MINOR_VERSION}" --plat-name macosx_11_0_"$(uname -m)"
-  else
-    "$PYTHON_BIN" setup.py bdist_wheel --python-tag py3"${PYTHON_MINOR_VERSION}"
+
+  if [ "$IS_NIGHTLY" == true ]; then
+    WHEEL_BLD_ARGS="egg_info --tag-build=.dev --tag-date"
   fi
+  WHEEL_BLD_ARGS="${WHEEL_BLD_ARGS} bdist_wheel --python-tag py3${PYTHON_MINOR_VERSION}"
+  if [ "$(uname)" == "Darwin" ]; then
+    WHEEL_BLD_ARGS="${WHEEL_BLD_ARGS} --plat-name macosx_11_0_$(uname -m)"
+  fi
+  "$PYTHON_BIN" setup.py $WHEEL_BLD_ARGS
 
   cp 'dist/'*.whl "${DEST}"
 

--- a/grain/oss/runner_common.sh
+++ b/grain/oss/runner_common.sh
@@ -38,6 +38,7 @@ build_and_test_grain_linux() {
       --env BAZEL_VERSION="${BAZEL_VERSION}" \
       --env AUDITWHEEL_PLATFORM="${AUDITWHEEL_PLATFORM}" \
       --env RUN_TESTS="${RUN_TESTS}" \
+      --env IS_NIGHTLY="${IS_NIGHTLY}" \
       -v "${SOURCE_DIR}":"${OUTPUT_DIR}" \
       --name grain grain:"${PYTHON_VERSION}" \
       sh grain/oss/build_whl.sh
@@ -146,6 +147,7 @@ build_and_test_grain() {
       --env BAZEL_VERSION="${BAZEL_VERSION}" \
       --env AUDITWHEEL_PLATFORM="${AUDITWHEEL_PLATFORM}" \
       --env RUN_TESTS="$RUN_TESTS" \
+      --env IS_NIGHTLY="${IS_NIGHTLY}" \
       -v "${SOURCE_DIR}":"${OUTPUT_DIR}" \
       --name grain grain:"${PYTHON_VERSION}" \
       sh grain/oss/build_whl.sh


### PR DESCRIPTION
This PR should be merged after #877 

Hi @iindyk,

Here I separated publishing yamls into `publish_nightly` and `publish_release` and both reuse one template.


`publish_nightly` has a weekly schedule and this workflow sets `IS_NIGHTLY=true`, so that the release tag is, e.g.:
```
grain-0.2.9.dev20250523-cp310-cp310-linux_x86_64.whl
```

Some comments:

- With this change **there's one new rule**: Once a new release is out, e.g. `0.2.10`, in the codebase `version = ...` in `pyproject.toml` needs to be updated to `0.2.11`, so that nightly builds are versioned as `0.2.11.dev...`. [NumPy does that](https://github.com/numpy/numpy/blob/bbdebaedcc44eabc2dc4cdfcbbff5361328f6a56/pyproject.toml#L10), a `2.3.0` was released, `2.3.x` branch was created and in `main` it's `2.4.0` now (for Grain we have a simplified version, without branching and bugfix releases, but once `1.0.0` is out Grain could also do this).
- Version is repeated in two places, `pyproject.toml` and `MODULE.bazel`. Do we need one in the Bazel file? Ideally version should be in once place, preferably `pyproject.toml` IMO. (I've never used Bazel before so I might be wrong here)
