### PR TITLE
Windows build

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -11,6 +11,10 @@ on:
         default: true
         type: boolean
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: read
 
@@ -23,9 +27,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-2022]
 
     steps:
+      - name: Set up Bazel
+        if: ${{ matrix.os == 'windows-2022' }}
+        uses: bazel-contrib/setup-bazel@0.15.0
+      - name: Set up Python
+        if: ${{ matrix.os == 'windows-2022' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - uses: "actions/checkout@v3"
       - name: Create directory
         run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,14 +17,14 @@ module(
     repo_name = "com_google_grain",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.6.1")
-bazel_dep(name = "platforms", version = "0.0.8")
-bazel_dep(name = "rules_python", version = "0.37.0")
-bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_python", version = "0.40.0")
+bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "pybind11_bazel", version = "2.11.1")
 bazel_dep(name = "abseil-py", version = "2.1.0")
-bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1")
-bazel_dep(name = "protobuf", version = "24.4", repo_name = "com_google_protobuf")
+bazel_dep(name = "abseil-cpp", version = "20240116.1")
+bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/grain/oss/runner_common.sh
+++ b/grain/oss/runner_common.sh
@@ -120,34 +120,45 @@ build_and_test_grain_macos() {
 # Python version specified in PYTHON_VERSION.
 build_and_test_grain() {
   printf 'Creating Grain wheel for Python Version %s\n' "$PYTHON_VERSION"
-  if [ "$(uname)" = "Darwin" ]; then
-    update_bazel_macos "${BAZEL_VERSION}"
-    bazel --version
-    setup_env_vars_py "$PYTHON_MAJOR_VERSION" "$PYTHON_MINOR_VERSION"
-    install_and_init_pyenv "${PYENV_ROOT}"
-    install_grain_deps
-    sh "${SOURCE_DIR}"'/grain/oss/build_whl.sh'
-  else
-    # Automatically decide which platform to build for by checking on which
-    # platform this runs.
-    AUDITWHEEL_PLATFORM='manylinux2014_'"$(uname -m)"
-    docker rmi -f grain:${PYTHON_VERSION}
-    docker rm -f grain
-    DOCKER_BUILDKIT=1 docker build --progress=plain --no-cache \
-      --build-arg AUDITWHEEL_PLATFORM="${AUDITWHEEL_PLATFORM}" \
-      --build-arg PYTHON_VERSION="${PYTHON_MAJOR_VERSION}""${PYTHON_MINOR_VERSION}" \
-      --build-arg BAZEL_VERSION="${BAZEL_VERSION}" \
-      -t grain:"${PYTHON_VERSION}" "${SOURCE_DIR}"'/grain/oss'
-  
-    docker run --rm -a stdin -a stdout -a stderr \
-      --env PYTHON_VERSION="${PYTHON_MAJOR_VERSION}"'.'"${PYTHON_MINOR_VERSION}" \
-      --env PYTHON_MAJOR_VERSION="${PYTHON_MAJOR_VERSION}" \
-      --env PYTHON_MINOR_VERSION="${PYTHON_MINOR_VERSION}" \
-      --env BAZEL_VERSION="${BAZEL_VERSION}" \
-      --env AUDITWHEEL_PLATFORM="${AUDITWHEEL_PLATFORM}" \
-      --env RUN_TESTS="$RUN_TESTS" \
-      -v "${SOURCE_DIR}":"${OUTPUT_DIR}" \
-      --name grain grain:"${PYTHON_VERSION}" \
-      sh grain/oss/build_whl.sh
-  fi
+  case "$(uname)" in
+    Darwin*)
+      update_bazel_macos "${BAZEL_VERSION}"
+      bazel --version
+      setup_env_vars_py "$PYTHON_MAJOR_VERSION" "$PYTHON_MINOR_VERSION"
+      install_and_init_pyenv "${PYENV_ROOT}"
+      install_grain_deps
+      sh "${SOURCE_DIR}"'/grain/oss/build_whl.sh'
+      ;;
+    CYGWIN*|MINGW*|MSYS_NT*)
+      PYTHON_BIN="$(which python)"
+      export PYTHON_BIN
+      bazel --version
+      setup_env_vars_py "$PYTHON_MAJOR_VERSION" "$PYTHON_MINOR_VERSION"
+      install_grain_deps
+      sh "${SOURCE_DIR}"'/grain/oss/build_whl.sh'
+      ;;
+    *)
+      # Automatically decide which platform to build for by checking on which
+      # platform this runs.
+      AUDITWHEEL_PLATFORM='manylinux2014_'"$(uname -m)"
+      docker rmi -f grain:${PYTHON_VERSION}
+      docker rm -f grain
+      DOCKER_BUILDKIT=1 docker build --progress=plain --no-cache \
+        --build-arg AUDITWHEEL_PLATFORM="${AUDITWHEEL_PLATFORM}" \
+        --build-arg PYTHON_VERSION="${PYTHON_MAJOR_VERSION}""${PYTHON_MINOR_VERSION}" \
+        --build-arg BAZEL_VERSION="${BAZEL_VERSION}" \
+        -t grain:"${PYTHON_VERSION}" "${SOURCE_DIR}"'/grain/oss'
+
+      docker run --rm -a stdin -a stdout -a stderr \
+        --env PYTHON_VERSION="${PYTHON_MAJOR_VERSION}"'.'"${PYTHON_MINOR_VERSION}" \
+        --env PYTHON_MAJOR_VERSION="${PYTHON_MAJOR_VERSION}" \
+        --env PYTHON_MINOR_VERSION="${PYTHON_MINOR_VERSION}" \
+        --env BAZEL_VERSION="${BAZEL_VERSION}" \
+        --env AUDITWHEEL_PLATFORM="${AUDITWHEEL_PLATFORM}" \
+        --env RUN_TESTS="$RUN_TESTS" \
+        -v "${SOURCE_DIR}":"${OUTPUT_DIR}" \
+        --name grain grain:"${PYTHON_VERSION}" \
+        sh grain/oss/build_whl.sh
+        ;;
+  esac
 }


### PR DESCRIPTION
Here's a draft PR with Windows build support.

Some comments:
- I think it's worth considering to switch to `setup-bazel` and `setup-python` Actions for Bazel and Python setup for all environments, rather than downloading and installing them in the script.
  I couldn't make it work with the current pyenv and bazel installation - switching to GitHub Actions worked out of the box.
- The Bazel setup complained about `Module.bazel` dependencies versions - I upgraded them.
- It seems that the wheel build is so far blocked by `array-record` - package: https://pypi.org/project/array-record/#history. The current setup requires `0.7.2` but Windows wheels for it is missing and the last one goes back to `0.4.1`: https://github.com/mtsokol/grain/actions/runs/15418522140/job/43387085894.
  I think that first we need to make sure that all dependencies have Windows distributions. 
