### PR TITLE
Upgrade Bazel to `7.2.1`

### DIFF
--- a/.github/workflows/build_and_publish_template.yml
+++ b/.github/workflows/build_and_publish_template.yml
@@ -34,7 +34,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14]
 
     env:
-      USE_BAZEL_VERSION: "7.1.1"
+      USE_BAZEL_VERSION: "7.2.1"
     steps:
       - name: Set up Bazel
         uses: bazel-contrib/setup-bazel@0.15.0
@@ -57,7 +57,7 @@ jobs:
           export PYTHON_VERSION=${{ matrix.python-version }}
           export PYTHON_MAJOR_VERSION=$(echo $PYTHON_VERSION | cut -d. -f1)
           export PYTHON_MINOR_VERSION=$(echo $PYTHON_VERSION | cut -d. -f2)
-          export BAZEL_VERSION="7.1.1"
+          export BAZEL_VERSION="7.2.1"
           export OUTPUT_DIR="/tmp/grain"
           export SOURCE_DIR="/tmp/grain"
           export RUN_TESTS=${{ inputs.run_tests }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           export PYTHON_VERSION=${{ matrix.python-version }}
           export PYTHON_MAJOR_VERSION=$(echo $PYTHON_VERSION | cut -d. -f1)
           export PYTHON_MINOR_VERSION=$(echo $PYTHON_VERSION | cut -d. -f2)
-          export BAZEL_VERSION="7.1.1"
+          export BAZEL_VERSION="7.2.1"
           export AUDITWHEEL_PLATFORM="manylinux2014_x86_64"
           export RUN_TESTS="true"
           cd /tmp/grain

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
-bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "platforms", version = "0.0.9")
 bazel_dep(name = "rules_python", version = "0.37.0")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "pybind11_bazel", version = "2.11.1")

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -104,3 +104,14 @@ git add docs/tutorials/new_tutorial.*          # stage the new changes
 pre-commit run                       # run pre-commit checks on added files
 git add docs/tutorials/new_tutorial.*          # stage the files updated by pre-commit
 git commit -m "Update new tutorial"  # commit to the branch
+```
+
+### Release procedure
+
+Grain release can be done by running the "Build and Publish Release" workflow. It builds
+wheels for all supported platforms and uploads them to PyPI.
+
+IMPORTANT! Please remember to bump `version` entry in `MODULE.bazel` and `pyproject.toml`
+files after each release. This will allow the nightly workflow to have correct identifier.
+E.g. if you just released `0.2.10`, push a commit that moves version entry to the next
+anticipated release, such as `0.2.11` or `0.3.0`.

--- a/grain/_src/core/version.py
+++ b/grain/_src/core/version.py
@@ -24,7 +24,7 @@ def _get_version():
     version = importlib_metadata.version("grain")
   except importlib_metadata.PackageNotFoundError:
     # Fallback version
-    version = "0.2.10"
+    version = "0.2.11"
   return version
 
 

--- a/grain/oss/runner_common.sh
+++ b/grain/oss/runner_common.sh
@@ -1,4 +1,3 @@
-
 #!/bin/sh
 
 set -e -x


### PR DESCRIPTION
Hi @iindyk,

Here's a PR that upgrades Bazel to `7.2.1`. The change is minimal (only `platforms` dependency) and it will allow to progress on conda forge feedstock. In my fork the CI passed: https://github.com/mtsokol/grain/actions/runs/15935377292

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--922.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->