### PR TITLE
Update `__array_wrap__` signature

### DIFF
--- a/grain/_src/python/shared_memory_array.py
+++ b/grain/_src/python/shared_memory_array.py
@@ -79,11 +79,11 @@ class SharedMemoryArray(np.ndarray):
       self.shm = None
     self._unlink_on_del = getattr(obj, "_unlink_on_del", False)
 
-  def __array_wrap__(self, obj, context=None):  # pylint: disable=unused-argument
+  def __array_wrap__(self, obj, context=None, return_scalar=False):  # pylint: disable=unused-argument
     # This follows the `numpy.memmap` implementation
     if self is obj or type(self) is not type(self):
       return obj
-    if not obj.shape:
+    if return_scalar:
       return obj[()]
     return obj.view(np.ndarray)
 


### PR DESCRIPTION
This PR updates `__array_wrap__` signature to [match `numpy.memmap` implementation](https://github.com/numpy/numpy/blob/2bb4005d189667b71a6088db358f8848802f36e9/numpy/_core/memmap.py#L342) and get rid of a deprecation warning for NumPy 2.x. Can be reproduced with:
```py
from grain._src.python.shared_memory_array import SharedMemoryArray
import numpy as np

a = SharedMemoryArray((1, 2, 3))
b = SharedMemoryArray((1, 2, 3))

np.allclose(a, b)
```

CC @vfdev-5

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--923.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->