### PR TITLE
[DOCS] Introduce changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change log
+
+The change log file hosting all releases with lists of new features and breaking changes.
+Best viewed [here](https://docs.jax.dev/en/latest/changelog.html).
+
+## Unreleased
+
+## Grain 0.2.10 (June 16, 2025)
+
+* New features:
+  * Automatic publishing releases to PyPI via GitHub actions.
+  * Nightly builds.
+
+* Changes:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [**Installation**](#installation)
 | [**Quickstart**](#quickstart)
 | [**Reference docs**](https://google-grain.readthedocs.io/en/latest/)
+| [**Change logs**](https://google-grain.readthedocs.io/en/latest/changelog.html)
 
 Grain is a Python library for reading and processing data for training and
 evaluating JAX models. It is flexible, fast and deterministic.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,2 @@
+```{include} ../CHANGELOG.md
+```

--- a/docs/data_loader/samplers.md
+++ b/docs/data_loader/samplers.md
@@ -5,8 +5,6 @@ are processed. This allows Grain to implement global transformations (e.g.
 global shuffling, sharding, repeating for multiple epochs) before reading any
 records.
 
-
-
 Samplers need to implement the following iterator protocol:
 
 ```python

--- a/docs/data_loader/transformations.md
+++ b/docs/data_loader/transformations.md
@@ -1,11 +1,5 @@
 # Transformations
 
-
-
-.md
-
-
-
 Grain Transforms interface denotes transformations which are applied to data. In
 the case of local transformations (such as map, random map, filter), the
 transforms receive an element on which custom changes are applied. For global

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -1,11 +1,5 @@
 # Data Sources
 
-
-
-.md
-
-
-
 A Grain data source is responsible for retrieving individual records. Records
 could be in a file/storage system or generated on the fly. Data sources need to
 implement the following protocol:

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,7 @@ tutorials/data_sources/index
 :hidden:
 :caption: API reference
 grain
+changelog
 ```
 
 ``` {toctree}


### PR DESCRIPTION
Hi @iindyk,

Here's a PR with `CHANGELOG.md` file, similar to one in JAX repo. 

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--927.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->