### PR TITLE
Docs: Fix ArrayRecord hyperlink

### DIFF
--- a/docs/tutorials/data_loader_tutorial.md
+++ b/docs/tutorials/data_loader_tutorial.md
@@ -96,7 +96,7 @@ index_sampler = grain.IndexSampler(
 ## Data source
 A data source is responsible for reading indvidual records from underlying files / storage system. We provide the following data sources:
 
-*   `ArrayRecordDataSource`: reads records from [ArrayRecord](go/array-record-design) files.
+*   `ArrayRecordDataSource`: reads records from [ArrayRecord](https://github.com/google/array_record) files.
 *   `tfds.data_source`: data source for [TFDS](https://www.tensorflow.org/datasets) datasets without a TensorFlow dependency.
 
 


### PR DESCRIPTION
Updated the broken ArrayRecord hyperlink with the correct URL. Thanks!