### PR TITLE
Add `batch_fn` to `load`, `Batch` and `BatchOperation`.

### DIFF
--- a/grain/_src/core/transforms.py
+++ b/grain/_src/core/transforms.py
@@ -119,6 +119,7 @@ class FlatMapTransform(abc.ABC):
 class Batch:
   batch_size: int
   drop_remainder: bool = False
+  batch_fn: Callable[[Sequence[Any]], Any] | None = None
 
 
 Transformation = Union[

--- a/grain/_src/python/data_loader.py
+++ b/grain/_src/python/data_loader.py
@@ -215,6 +215,7 @@ class DataLoader:
         batch_operation = BatchOperation(
             batch_size=operations[-1].batch_size,
             drop_remainder=operations[-1].drop_remainder,
+            batch_fn=operations[-1].batch_fn,
         )
         batch_operation.disable_deprecation_message()
         operations = list(operations)
@@ -599,6 +600,7 @@ def _apply_transform(
     batch_op = BatchOperation(
         batch_size=transform.batch_size,
         drop_remainder=transform.drop_remainder,
+        batch_fn=transform.batch_fn,
     )
     batch_op.disable_deprecation_message()
     for r in batch_op(input_iterator):

--- a/grain/_src/python/operations.py
+++ b/grain/_src/python/operations.py
@@ -130,6 +130,7 @@ class BatchOperation(Generic[_IN, _OUT]):
 
   batch_size: int
   drop_remainder: bool = False
+  batch_fn: Callable[[Sequence[_IN]], _OUT] | None = None
 
   def __post_init__(self):
     if self.batch_size <= 0:
@@ -138,6 +139,7 @@ class BatchOperation(Generic[_IN, _OUT]):
       )
     self._use_shared_memory = False
     self._display_deprecation_message = True
+    self.batch_fn = self._batch if self.batch_fn is None else self.batch_fn
 
   def __call__(
       self, input_iterator: Iterator[record.Record[_IN]]
@@ -153,13 +155,13 @@ class BatchOperation(Generic[_IN, _OUT]):
       last_record_metadata = input_record.metadata
       records_to_batch.append(input_record.data)
       if len(records_to_batch) == self.batch_size:
-        batch = self._batch(records_to_batch)
+        batch = self.batch_fn(records_to_batch)
         records_to_batch = []
         yield record.Record(last_record_metadata.remove_record_key(), batch)
     if records_to_batch and not self.drop_remainder:
       yield record.Record(
           last_record_metadata.remove_record_key(),  # pytype: disable=attribute-error
-          self._batch(records_to_batch),
+          self.batch_fn(records_to_batch),
       )
 
   def _enable_shared_memory(self):


### PR DESCRIPTION
Related to #935

This PR adds `batch_fn` to `grain.load`, `grain.transforms.Batch`, and `grain._src.python.operations.BatchOperation` which enables users to use `batch_fn` with `grain.DataLoader`.

I did not run the added tests with the Grain test suite because I'm not familiar with Bazel and absl.testing. I only verified the logic using a custom script.

Please guide me on how to run the tests if needed. Thanks.