### PR TITLE
Implement feature to allow maximum sequences per segment for packed inputs

### DIFF
--- a/grain/BUILD
+++ b/grain/BUILD
@@ -1,47 +1,76 @@
-load("@python//3.10:defs.bzl", compile_pip_requirements_3_10 = "compile_pip_requirements")
-load("@python//3.11:defs.bzl", compile_pip_requirements_3_11 = "compile_pip_requirements")
-load("@python//3.12:defs.bzl", compile_pip_requirements_3_12 = "compile_pip_requirements")
-load("@python//3.13:defs.bzl", compile_pip_requirements_3_13 = "compile_pip_requirements")
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//grain:__subpackages__"])
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+# Backwards compatibility alias.
+alias(
+    name = "python",
+    actual = ":grain",
+    visibility = ["//visibility:public"],
+)
 
 py_library(
-    name = "setup",
-    srcs = ["setup.py"],
+    name = "grain",
+    srcs = [
+        "__init__.py",
+        "_src/__init__.py",
+        "checkpoint.py",
+        "constants.py",
+        "experimental.py",
+        "multiprocessing.py",
+        "python/__init__.py",
+        "python/experimental.py",
+        "samplers.py",
+        "sharding.py",
+        "sources.py",
+        "transforms.py",
+    ],
     srcs_version = "PY3",
-)
-
-compile_pip_requirements_3_10(
-    name = "requirements_3_10",
-    requirements_in = "test_requirements.in",
-    requirements_txt = "test_requirements_lock_3_10.txt",
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
+    data = select({
+        "@platforms//os:windows": ["//grain/_src/python/experimental/index_shuffle/python:index_shuffle_module.pyd"],
+       "//conditions:default": ["//grain/_src/python/experimental/index_shuffle/python:index_shuffle_module.so"],
     }),
-)
-compile_pip_requirements_3_11(
-    name = "requirements_3_11",
-    requirements_in = "test_requirements.in",
-    requirements_txt = "test_requirements_lock_3_11.txt",
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-)
-compile_pip_requirements_3_12(
-    name = "requirements_3_12",
-    requirements_in = "test_requirements.in",
-    requirements_txt = "test_requirements_lock_3_12.txt",
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-)
-compile_pip_requirements_3_13(
-    name = "requirements_3_13",
-    requirements_in = "test_requirements.in",
-    requirements_txt = "test_requirements_lock_3_13.txt",
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    # Implicit build flag
+    visibility = ["//visibility:public"],
+    deps = [
+        "//grain/_src/core:config",
+        "//grain/_src/core:constants",
+        "//grain/_src/core:monitoring",
+        "//grain/_src/core:sharding",
+        "//grain/_src/core:transforms",
+        "//grain/_src/core:version",
+        "//grain/_src/python:checkpoint_handlers",
+        "//grain/_src/python:data_loader",
+        "//grain/_src/python:data_sources",
+        "//grain/_src/python:load",
+        "//grain/_src/python:operations",
+        "//grain/_src/python:options",
+        "//grain/_src/python:record",
+        "//grain/_src/python:samplers",
+        "//grain/_src/python:shared_memory_array",
+        "//grain/_src/python/dataset",
+        "//grain/_src/python/dataset:base",
+        "//grain/_src/python/dataset:elastic_iterator",
+        "//grain/_src/python/dataset:stats",
+        "//grain/_src/python/dataset:visualize",
+        "//grain/_src/python/dataset/sources:parquet_dataset",
+        "//grain/_src/python/dataset/sources:tfrecord_dataset",
+        "//grain/_src/python/dataset/transformations:interleave",
+        "//grain/_src/python/dataset/transformations:prefetch_autotune",
+        "//grain/_src/python/dataset/transformations:limit",
+        "//grain/_src/python/dataset/transformations:packing",
+        "//grain/_src/python/dataset/transformations:packing_concat_then_split",
+        "//grain/_src/python/dataset/transformations:zip",
+        "//grain/_src/python/experimental/device_put",
+        "//grain/_src/python/experimental/example_packing:packing",
+        "//grain/_src/python/testing:experimental",
+        "//grain/proto:execution_summary_py_pb2",
+    ],
 )

--- a/grain/BUILD
+++ b/grain/BUILD
@@ -1,76 +1,47 @@
-
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
-
-package(default_visibility = ["//grain:__subpackages__"])
-
-licenses(["notice"])
-
-exports_files(["LICENSE"])
-
-# Backwards compatibility alias.
-alias(
-    name = "python",
-    actual = ":grain",
-    visibility = ["//visibility:public"],
-)
+load("@python//3.10:defs.bzl", compile_pip_requirements_3_10 = "compile_pip_requirements")
+load("@python//3.11:defs.bzl", compile_pip_requirements_3_11 = "compile_pip_requirements")
+load("@python//3.12:defs.bzl", compile_pip_requirements_3_12 = "compile_pip_requirements")
+load("@python//3.13:defs.bzl", compile_pip_requirements_3_13 = "compile_pip_requirements")
 
 py_library(
-    name = "grain",
-    srcs = [
-        "__init__.py",
-        "_src/__init__.py",
-        "checkpoint.py",
-        "constants.py",
-        "experimental.py",
-        "multiprocessing.py",
-        "python/__init__.py",
-        "python/experimental.py",
-        "samplers.py",
-        "sharding.py",
-        "sources.py",
-        "transforms.py",
-    ],
+    name = "setup",
+    srcs = ["setup.py"],
     srcs_version = "PY3",
-    data = select({
-        "@platforms//os:windows": ["//grain/_src/python/experimental/index_shuffle/python:index_shuffle_module.pyd"],
-       "//conditions:default": ["//grain/_src/python/experimental/index_shuffle/python:index_shuffle_module.so"],
+)
+
+compile_pip_requirements_3_10(
+    name = "requirements_3_10",
+    requirements_in = "test_requirements.in",
+    requirements_txt = "test_requirements_lock_3_10.txt",
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
     }),
-    # Implicit build flag
-    visibility = ["//visibility:public"],
-    deps = [
-        "//grain/_src/core:config",
-        "//grain/_src/core:constants",
-        "//grain/_src/core:monitoring",
-        "//grain/_src/core:sharding",
-        "//grain/_src/core:transforms",
-        "//grain/_src/core:version",
-        "//grain/_src/python:checkpoint_handlers",
-        "//grain/_src/python:data_loader",
-        "//grain/_src/python:data_sources",
-        "//grain/_src/python:load",
-        "//grain/_src/python:operations",
-        "//grain/_src/python:options",
-        "//grain/_src/python:record",
-        "//grain/_src/python:samplers",
-        "//grain/_src/python:shared_memory_array",
-        "//grain/_src/python/dataset",
-        "//grain/_src/python/dataset:base",
-        "//grain/_src/python/dataset:elastic_iterator",
-        "//grain/_src/python/dataset:stats",
-        "//grain/_src/python/dataset:visualize",
-        "//grain/_src/python/dataset/sources:parquet_dataset",
-        "//grain/_src/python/dataset/sources:tfrecord_dataset",
-        "//grain/_src/python/dataset/transformations:interleave",
-        "//grain/_src/python/dataset/transformations:prefetch_autotune",
-        "//grain/_src/python/dataset/transformations:limit",
-        "//grain/_src/python/dataset/transformations:packing",
-        "//grain/_src/python/dataset/transformations:packing_concat_then_split",
-        "//grain/_src/python/dataset/transformations:zip",
-        "//grain/_src/python/experimental/device_put",
-        "//grain/_src/python/experimental/example_packing:packing",
-        "//grain/_src/python/testing:experimental",
-        "//grain/proto:execution_summary_py_pb2",
-    ],
+)
+compile_pip_requirements_3_11(
+    name = "requirements_3_11",
+    requirements_in = "test_requirements.in",
+    requirements_txt = "test_requirements_lock_3_11.txt",
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)
+compile_pip_requirements_3_12(
+    name = "requirements_3_12",
+    requirements_in = "test_requirements.in",
+    requirements_txt = "test_requirements_lock_3_12.txt",
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)
+compile_pip_requirements_3_13(
+    name = "requirements_3_13",
+    requirements_in = "test_requirements.in",
+    requirements_txt = "test_requirements_lock_3_13.txt",
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )

--- a/grain/_src/python/dataset/transformations/packing.py
+++ b/grain/_src/python/dataset/transformations/packing.py
@@ -54,6 +54,7 @@ class FirstFitPackIterDataset(dataset.IterDataset):
       shuffle_bins: bool = True,
       shuffle_bins_group_by_feature: str | None = None,
       meta_features: Sequence[str] = (),
+      max_sequences_per_bin: int | None = None,
   ):
     """Creates a dataset that packs sequences from the parent dataset.
 
@@ -72,6 +73,8 @@ class FirstFitPackIterDataset(dataset.IterDataset):
         within each epoch to avoid epoch leakage.
       meta_features: Meta features that do not need *_segment_ids and
         *_positions features.
+      max_sequences_per_bin: The maximum number of sequences that can be packed
+        into a bin
     """
     super().__init__(parent)
     self._length_struct = length_struct
@@ -80,6 +83,7 @@ class FirstFitPackIterDataset(dataset.IterDataset):
     self._shuffle_bins = shuffle_bins
     self._shuffle_bins_group_by_feature = shuffle_bins_group_by_feature
     self._meta_features = meta_features
+    self._max_sequences_per_bin = max_sequences_per_bin
 
   def __str__(self) -> str:
     return "FirstFitPackIterDataset"
@@ -93,6 +97,7 @@ class FirstFitPackIterDataset(dataset.IterDataset):
         shuffle_bins=self._shuffle_bins,
         shuffle_bins_group_by_feature=self._shuffle_bins_group_by_feature,
         meta_features=self._meta_features,
+        max_sequences_per_bin = self._max_sequences_per_bin,
     )
 
 
@@ -109,6 +114,7 @@ class FirstFitPackDatasetIterator(dataset.DatasetIterator):
       shuffle_bins: bool,
       shuffle_bins_group_by_feature: str | None,
       meta_features: Sequence[str],
+      max_sequences_per_bin: int | None,
   ):
     super().__init__(parent)
     self._num_packing_bins = num_packing_bins
@@ -117,6 +123,7 @@ class FirstFitPackDatasetIterator(dataset.DatasetIterator):
     self._shuffle_bins = shuffle_bins
     self._shuffle_bins_group_by_feature = shuffle_bins_group_by_feature
     self._meta_features = meta_features
+    self._max_sequences_per_bin = max_sequences_per_bin
     self._reset()
 
   def _reset(self):
@@ -197,6 +204,7 @@ class FirstFitPackDatasetIterator(dataset.DatasetIterator):
           self._num_packing_bins,
           self._length_struct,
           meta_features=self._meta_features,
+          max_sequences_per_bin=self._max_sequences_per_bin,
       )
 
   @dataset_stats.record_next_duration_if_output
@@ -251,6 +259,7 @@ class FirstFitPackDatasetIterator(dataset.DatasetIterator):
               self._num_packing_bins,
               self._length_struct,
               meta_features=self._meta_features,
+              max_sequences_per_bin=self._max_sequences_per_bin,
           )
 
         # Try adding element to the current packed batch.

--- a/grain/_src/python/dataset/transformations/packing.py
+++ b/grain/_src/python/dataset/transformations/packing.py
@@ -61,6 +61,7 @@ class PackingDatasetIterator(dataset.DatasetIterator):
       meta_features: Meta features that do not require packing.
       pack_alignment_struct: Optional per-feature alignment values.
       padding_struct: Optional per-feature padding values.
+      max_sequences_per_bin: Optional maximum number of input sequences that can be packed into a bin
     """
     super().__init__(parent)
     self._packer_cls = packer_cls
@@ -261,6 +262,7 @@ class PackIterDataset(dataset.IterDataset):
       meta_features: Sequence[str] = (),
       pack_alignment_struct: Any = None,
       padding_struct: Any = None,
+      max_sequences_per_bin: int | None = None,
   ):
     """Initializes the generic packing dataset.
 
@@ -275,6 +277,7 @@ class PackIterDataset(dataset.IterDataset):
       meta_features: Meta features that do not need packing logic.
       pack_alignment_struct: Optional per-feature alignment values.
       padding_struct: Optional per-feature padding values.
+      max_sequences_per_bin: Optional maximum number of input sequences that can be packed into a bin
     """
     super().__init__(parent)
     self._packer_cls = packer_cls
@@ -286,6 +289,7 @@ class PackIterDataset(dataset.IterDataset):
     self._meta_features = meta_features
     self._pack_alignment_struct = pack_alignment_struct
     self._padding_struct = padding_struct
+    self._max_sequences_per_bin = max_sequences_per_bin
 
   def __iter__(self) -> dataset.DatasetIterator:
     return PackingDatasetIterator(
@@ -299,6 +303,7 @@ class PackIterDataset(dataset.IterDataset):
         meta_features=self._meta_features,
         pack_alignment_struct=self._pack_alignment_struct,
         padding_struct=self._padding_struct,
+        max_sequences_per_bin = self._max_sequences_per_bin,
     )
 
 
@@ -331,6 +336,7 @@ class FirstFitPackIterDataset(PackIterDataset):
       meta_features: Sequence[str] = (),
       pack_alignment_struct: Any = None,
       padding_struct: Any = None,
+      max_sequences_per_bin: int | None = None,      
   ):
     """Creates a dataset that packs sequences using the first-fit strategy.
 
@@ -344,6 +350,7 @@ class FirstFitPackIterDataset(PackIterDataset):
       meta_features: Meta features that do not need packing logic.
       pack_alignment_struct: Optional per-feature alignment values.
       padding_struct: Optional per-feature padding values.
+      max_sequences_per_bin: Optional maximum number of input sequences that can be packed into a bin
     """
     super().__init__(
         parent,
@@ -356,6 +363,7 @@ class FirstFitPackIterDataset(PackIterDataset):
         meta_features=meta_features,
         pack_alignment_struct=pack_alignment_struct,
         padding_struct=padding_struct,
+        max_sequences_per_bin=max_sequences_per_bin,
     )
 
   def __str__(self) -> str:
@@ -384,6 +392,7 @@ class BestFitPackIterDataset(PackIterDataset):
       meta_features: Sequence[str] = (),
       pack_alignment_struct: Any = None,
       padding_struct: Any = None,
+      max_sequences_per_bin: int | None = None,      
   ):
     """Creates a dataset that packs sequences using the best-fit strategy.
 
@@ -397,6 +406,7 @@ class BestFitPackIterDataset(PackIterDataset):
       meta_features: Meta features that do not need packing logic.
       pack_alignment_struct: Optional per-feature alignment values.
       padding_struct: Optional per-feature padding values.
+      max_sequences_per_bin: Optional maximum number of input sequences that can be packed into a bin
     """
     super().__init__(
         parent,
@@ -409,6 +419,7 @@ class BestFitPackIterDataset(PackIterDataset):
         meta_features=meta_features,
         pack_alignment_struct=pack_alignment_struct,
         padding_struct=padding_struct,
+        max_sequences_per_bin=max_sequences_per_bin,
     )
 
   def __str__(self) -> str:

--- a/grain/_src/python/dataset/transformations/packing.py
+++ b/grain/_src/python/dataset/transformations/packing.py
@@ -45,7 +45,7 @@ class PackingDatasetIterator(dataset.DatasetIterator):
       meta_features: Sequence[str],
       pack_alignment_struct: Any = None,
       padding_struct: Any = None,
-      max_sequences_per_bin: int | None,
+      max_sequences_per_bin: int | None = None,
   ):
     """Initializes the generic packing iterator.
 

--- a/grain/_src/python/dataset/transformations/packing_packed_batch.py
+++ b/grain/_src/python/dataset/transformations/packing_packed_batch.py
@@ -291,11 +291,13 @@ class FirstFitPackedBatch(PackedBatch[_T]):
     num_features = len(self._flat_first_free_cell_per_row)
     features_fit = np.empty((num_features, self._num_packing_bins), dtype=bool)
     for i in range(num_features):
-      features_fit[i, :] = (
-          element_lengths[i] + self._flat_first_free_cell_per_row[i]
-      ) <= self._capacities[i] and (
-           (self._max_sequences_per_bin is None) or
-              (self._num_examples_per_row[i] < self._max_sequences_per_bin))
+      if ((self._max_sequences_per_bin is None) or 
+        (self._num_examples_per_row[i] < self._max_sequences_per_bin)):
+        features_fit[i, :] = (
+            element_lengths[i] + self._flat_first_free_cell_per_row[i]
+        ) <= self._capacities[i]
+      else:
+        features_fit[i, :] = False
 
     # Find the first row where all features fit.
     feasible_rows = np.all(features_fit, axis=0)
@@ -348,10 +350,11 @@ class BestFitPackedBatch(PackedBatch[_T]):
 
     free_cells_matrix = np.stack(self._flat_first_free_cell_per_row, axis=0)
     new_free_cells = free_cells_matrix + element_lengths[:, np.newaxis]
+    if self._max_sequences_per_bin is not None:
+        sequence_mask = np.where(self._num_examples_per_row < self._max_sequences_per_bin, 0, 1)
+        new_free_cells = new_free_cells + sequence_mask * self._capacities[:, np.newaxis]
     fittable_mask = np.all(
-        new_free_cells <= self._capacities[:, np.newaxis] and (
-           (self._max_sequences_per_bin is None) or
-              (self._num_examples_per_row[i] < self._max_sequences_per_bin)), axis=0
+        new_free_cells <= self._capacities[:, np.newaxis]
     )
 
     if not np.any(fittable_mask):

--- a/grain/_src/python/dataset/transformations/packing_packed_batch.py
+++ b/grain/_src/python/dataset/transformations/packing_packed_batch.py
@@ -291,7 +291,7 @@ class FirstFitPackedBatch(PackedBatch[_T]):
     num_features = len(self._flat_first_free_cell_per_row)
     features_fit = np.empty((num_features, self._num_packing_bins), dtype=bool)
     for i in range(num_features):
-      if ((self._max_sequences_per_bin is None) or 
+      if ((self._max_sequences_per_bin is None) or
         (self._num_examples_per_row[i] < self._max_sequences_per_bin)):
         features_fit[i, :] = (
             element_lengths[i] + self._flat_first_free_cell_per_row[i]
@@ -350,11 +350,12 @@ class BestFitPackedBatch(PackedBatch[_T]):
 
     free_cells_matrix = np.stack(self._flat_first_free_cell_per_row, axis=0)
     new_free_cells = free_cells_matrix + element_lengths[:, np.newaxis]
+
     if self._max_sequences_per_bin is not None:
         sequence_mask = np.where(self._num_examples_per_row < self._max_sequences_per_bin, 0, 1)
         new_free_cells = new_free_cells + sequence_mask * self._capacities[:, np.newaxis]
     fittable_mask = np.all(
-        new_free_cells <= self._capacities[:, np.newaxis]
+        new_free_cells <= self._capacities[:, np.newaxis], axis=0
     )
 
     if not np.any(fittable_mask):

--- a/grain/_src/python/dataset/transformations/packing_packed_batch.py
+++ b/grain/_src/python/dataset/transformations/packing_packed_batch.py
@@ -171,7 +171,6 @@ class PackedBatch(Generic[_T]):
 
   def can_add_at_row(
       self,
-      cls,
       element_feature_lengths: Any,  # PyTree[int]
       num_packing_bins: int,
       length_struct: Any,  # PyTree[int]

--- a/grain/_src/python/dataset/transformations/packing_packed_batch.py
+++ b/grain/_src/python/dataset/transformations/packing_packed_batch.py
@@ -352,8 +352,12 @@ class BestFitPackedBatch(PackedBatch[_T]):
     new_free_cells = free_cells_matrix + element_lengths[:, np.newaxis]
 
     if self._max_sequences_per_bin is not None:
-        sequence_mask = np.where(self._num_examples_per_row < self._max_sequences_per_bin, 0, 1)
-        new_free_cells = new_free_cells + sequence_mask * self._capacities[:, np.newaxis]
+      max_sequence_mask = np.where(
+        self._num_examples_per_row < self._max_sequences_per_bin, 0, 1
+      )
+      new_free_cells = (
+        new_free_cells + max_sequence_mask * self._capacities[:, np.newaxis]
+      )
     fittable_mask = np.all(
         new_free_cells <= self._capacities[:, np.newaxis], axis=0
     )

--- a/grain/_src/python/dataset/transformations/testing_util.py
+++ b/grain/_src/python/dataset/transformations/testing_util.py
@@ -1293,6 +1293,7 @@ class BaseFirstFitPackIterDatasetTest(parameterized.TestCase):
     ]
 
     _common_test_body(
+        self.packer_cls,
         input_elements,
         expected_elements,
         length_struct,
@@ -1480,6 +1481,7 @@ class BaseBestFitPackIterDatasetTest(BaseFirstFitPackIterDatasetTest):
     ]
 
     _common_test_body(
+        self.packer_cls,
         input_elements,
         expected_elements,
         length_struct,


### PR DESCRIPTION
This PR implements the feature request described in #1000

MaxText and MaxDiffusion (and probably others) use TransformerEngine for Flash Attention on GPUs.
When using packed inputs in THD format, TransformerEngine requires that the user specify the maximum segments packet into a sequence.

Grain did not previously support specifying maximum segment per sequence, which would cause data corruption in TransformerEngine if the limit was exceeded.

This PR allows the user to specify max segments per sequence in both the FirstFitPackIterDataset class and the deprecated PackAndBatchOperation class and includes tests for both.

PR #1028 mostly makes this PR obsolete because #1028 allows the user to override the packing and implement #1000 without duplicating a lot of code from grain, but this PR will still be useful because multiple consumers of grain need this feature and will not need to individually implement it.

Should #1028 be accepted, I'm happy to integrate this functionality with that one. I think that PR is great from the end-user perspective.



<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1039.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->