### PR TITLE
DOC: combine DataSources docs/tutorials, remove duplicates

### DIFF
--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -1,7 +1,0 @@
-# Data Sources
-
-A Grain data source is responsible for retrieving individual records. Records
-could be in a file/storage system or generated on the fly. 
-
-We provide a variety of data sources for Grain, which we discuss in the
-[tutorials](tutorials/data_sources/index) section.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,6 @@ not depend on TensorFlow.
 :caption: Get started
 installation
 api_choice
-data_sources
 behind_the_scenes
 ```
 

--- a/docs/tutorials/data_sources/index.rst
+++ b/docs/tutorials/data_sources/index.rst
@@ -4,8 +4,11 @@ Data Sources
 ============
 
 A `Grain` data source is responsible for retrieving individual records. Records
-could be in a file/storage system or generated on the fly. Data sources need to
-implement the following protocol:
+could be in a file/storage system or generated on the fly. There are two main kinds of
+data sources: those supporting efficient random access, and those only supporing a
+sequential access and can be iteratated over. 
+
+Data sources with random access need to implement the following protocol:
 
 .. code-block:: python
 
@@ -17,6 +20,17 @@ implement the following protocol:
 
       def __getitem__(self, record_key: SupportsIndex) -> T:
         """Retrieves record for the given record_key."""
+
+Data sources / datasets with no random access should implement the ``grain.IterDataset``
+(see the *Dataset basics* page for further details)
+
+.. code-block:: python
+
+    class IterDataset(_Dataset, Iterable[T]):
+      """Interface for datasets which can be iterated over."""
+      def __iter__(self) -> DatasetIterator[T]:
+        """Returns an iterator for this dataset."""
+
 
 
 File formats and available Data Sources
@@ -46,8 +60,8 @@ Implement your own Data Source
 ------------------------------
 
 You can implement your own data source and use it with `Grain`. It needs to
-implement the ``RandomAccessDataSource`` protocol defined above. In addition, you
-need to pay attention to the following:
+implement one of the ``RandomAccessDataSource`` or ``IterDataset`` protocols
+defined above. In addition, you need to pay attention to the following:
 
 *   **Data Sources should be pickleable.** This is because in the multi-worker
     setting, data sources are pickled and sent to child processes, where each
@@ -79,7 +93,16 @@ This section contains tutorials for using Grain to read data from various source
    parquet_dataset_tutorial.md
    arrayrecord_data_source_tutorial.md
    bagz_data_source_tutorial.md
-   load_from_s3_tutorial.md
-   load_from_gcs_tutorial.md
    huggingface_dataset_tutorial.md
    pytorch_dataset_tutorial.md
+
+File systems
+------------
+
+.. toctree::
+   :maxdepth: 1
+
+   load_from_s3_tutorial.md
+   load_from_gcs_tutorial.md
+
+


### PR DESCRIPTION
Combine the data source documentation, remove duplicates. Previously the docs were split between
https://google-grain.readthedocs.io/en/latest/data_sources.html and https://google-grain.readthedocs.io/en/latest/tutorials/data_sources/index.html, with the latter more complete.

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1162.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->