### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build_and_publish_template.yml
+++ b/.github/workflows/build_and_publish_template.yml
@@ -59,13 +59,13 @@ jobs:
           which bazel
           bazel version
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install rsync for Windows
         if: runner.os == 'Windows'
         run: choco install --no-progress rsync
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v6"
       - name: Create directory and set TEMP_DIR
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
@@ -93,7 +93,7 @@ jobs:
           build_and_test_grain
       - name: Upload Grain artifacts
         if: ${{ inputs.is_ci_tests == 'false' || inputs.is_ci_tests == false }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: built-grain-wheels-${{ matrix.os }}-${{ matrix.python-version }}
           path: "${{ env.WHL_DIR }}/all_dist/*.whl"
@@ -109,7 +109,7 @@ jobs:
       url: ${{ inputs.pypi_project_url }}
     steps:
       - name: Download Grain artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: built-grain-wheels-*
           path: dist/


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build_and_publish_template.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | build_and_publish_template.yml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | build_and_publish_template.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | build_and_publish_template.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.


<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1167.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->