### PR TITLE
Fix WindowShuffleDatasetIterator checkpoint restoration bug

### DIFF
--- a/grain/_src/python/dataset/transformations/shuffle.py
+++ b/grain/_src/python/dataset/transformations/shuffle.py
@@ -248,6 +248,7 @@ class _WindowShuffleDatasetIterator(dataset.DatasetIterator[T]):
         window_index=self._window_index,
         pos_in_window=self._pos_in_window,
         parent_exhausted=self._parent_exhausted,
+        init=self._init,
     )
 
   def set_state(self, state):
@@ -256,6 +257,7 @@ class _WindowShuffleDatasetIterator(dataset.DatasetIterator[T]):
     self._window_index = state["window_index"]
     self._pos_in_window = state["pos_in_window"]
     self._parent_exhausted = state["parent_exhausted"]
+    self._init = state.get("init", False)
     self._fill_and_shuffle_window()
     # Removed previously processed elements from the window.
     for _ in range(min(self._pos_in_window, len(self._window))):


### PR DESCRIPTION
This fixes a bug in _WindowShuffleDatasetIterator where the _init flag was not included in get_state()/set_state(), causing incorrect behavior when restoring checkpoints to a fresh iterator.

The bug manifested as:
- When creating a fresh iterator and restoring a checkpoint to it, the _init flag would remain True (from initialization)
- On the next window fill after restoration, _maybe_update_window_index() would see _init=True and not increment window_index
- This caused the same window_index to be used twice, leading to incorrect shuffle seeds and data mismatch

The fix:
- Include _init in the state dict returned by get_state()
- Restore _init in set_state() with backwards compatibility for old checkpoints (defaults to False if not present)

Added test test_checkpoint_restore_on_fresh_iterator that:
- Creates an iterator and checkpoints partway through a window
- Restores the checkpoint to a fresh iterator (not the same instance)
- Verifies data and window_index match between original and restored runs

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1179.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->