### PR TITLE
Propagate `close()` from `DatasetIterator` to data sources

### DIFF
--- a/grain/_src/python/dataset/dataset.py
+++ b/grain/_src/python/dataset/dataset.py
@@ -907,6 +907,14 @@ class MapDataset(_Dataset, Generic[T], metaclass=MapDatasetMeta):
     """Returns the Stats object for recording statistics about this dataset."""
     return self._initialize_stats(base.ExecutionTrackingMode.DISABLED)
 
+  def close(self) -> None:
+    """Closes the dataset and releases any resources by recursively closing all
+    parent datasets in the pipeline. This method is safe to call multiple
+    times.
+    """
+    for parent in self._parents:
+      parent.close()
+
   # pytype: enable=attribute-error
   # pylint: enable=protected-access
 

--- a/grain/_src/python/dataset/transformations/prefetch_test.py
+++ b/grain/_src/python/dataset/transformations/prefetch_test.py
@@ -1426,5 +1426,94 @@ class MultithreadPrefetchIterDatasetTest(parameterized.TestCase):
       self.assertEqual(context.process_count, num_workers)
 
 
+class _CloseTrackingDataSource:
+  """A data source that tracks close() calls and which threads called it."""
+
+  def __init__(self, data):
+    self._data = data
+    self.close_threads = []
+    self._lock = threading.Lock()
+
+  def __len__(self):
+    return len(self._data)
+
+  def __getitem__(self, index):
+    return self._data[index]
+
+  def close(self):
+    with self._lock:
+      self.close_threads.append(threading.current_thread().ident)
+
+
+class DataSourceCloseTest(parameterized.TestCase):
+  """Tests for data source close() propagation."""
+
+  def test_close_propagates_to_data_source(self):
+    source = _CloseTrackingDataSource([1, 2, 3, 4, 5])
+    ds = dataset.MapDataset.source(source)
+    num_threads = 2
+    read_options = options.ReadOptions(
+        num_threads=num_threads, prefetch_buffer_size=2
+    )
+    iter_ds = ds.to_iter_dataset(read_options=read_options)
+    it = iter(iter_ds)
+
+    _ = [next(it) for _ in range(3)]
+    self.assertEmpty(source.close_threads)
+
+    it.close()
+    # Called from each worker thread + main thread.
+    self.assertLen(source.close_threads, num_threads + 1)
+
+  def test_close_called_from_each_worker_thread(self):
+    source = _CloseTrackingDataSource([1, 2, 3, 4, 5])
+    ds = dataset.MapDataset.source(source)
+    num_threads = 4
+    read_options = options.ReadOptions(
+        num_threads=num_threads, prefetch_buffer_size=4
+    )
+    iter_ds = ds.to_iter_dataset(read_options=read_options)
+    it = iter(iter_ds)
+
+    _ = next(it)
+    it.close()
+
+    # Called from each worker thread + main thread.
+    self.assertLen(source.close_threads, num_threads + 1)
+
+  def test_close_without_prefetch(self):
+    source = _CloseTrackingDataSource([1, 2, 3])
+    ds = dataset.MapDataset.source(source)
+    read_options = options.ReadOptions(prefetch_buffer_size=0)
+    iter_ds = ds.to_iter_dataset(read_options=read_options)
+    it = iter(iter_ds)
+
+    _ = next(it)
+    it.close()
+    # No executor, so close called once from main thread.
+    self.assertLen(source.close_threads, 1)
+
+  def test_iterator_close_is_idempotent(self):
+    source = _CloseTrackingDataSource([1, 2, 3])
+    ds = dataset.MapDataset.source(source)
+    read_options = options.ReadOptions(prefetch_buffer_size=0)
+    iter_ds = ds.to_iter_dataset(read_options=read_options)
+    it = iter(iter_ds)
+
+    _ = next(it)
+    it.close()
+    it.close()
+    # Iterator close is idempotent.
+    self.assertLen(source.close_threads, 1)
+
+  def test_map_dataset_close_propagates(self):
+    source = _CloseTrackingDataSource([1, 2, 3, 4, 5])
+    ds = dataset.MapDataset.source(source).map(lambda x: x * 2).batch(2)
+
+    self.assertEmpty(source.close_threads)
+    ds.close()
+    self.assertLen(source.close_threads, 1)
+
+
 if __name__ == '__main__':
   absltest.main()

--- a/grain/_src/python/dataset/transformations/source.py
+++ b/grain/_src/python/dataset/transformations/source.py
@@ -138,6 +138,11 @@ class SourceMapDataset(dataset.MapDataset):
     else:
       return []
 
+  def close(self) -> None:
+    """Closes the underlying data source if it has a close method."""
+    if hasattr(self._source, "close"):
+      self._source.close()
+
 
 def log_lineage_for_sources(
     root: Union[dataset.MapDataset, dataset.IterDataset],


### PR DESCRIPTION
This follows up on #1069 to call `close` on the underlying data source if it implements a `close` method. This ensures resources are cleaned up properly. 

For multi-threaded prefetch, the `close` method is called once per thread and on the main thread to clean up thread-local resources. This means that `close` should be safe to call multiple times which aligns with Python standard practice, e.g., closing streams, database connections, and sockets in the standard library have this behavior.

---

The docs mention that Grain tries to use data sources as context managers if they implement the protocol, but that behavior is not currently implemented (cf. #936). The code provides the utility function [`use_context_if_available`](https://github.com/google/grain/blob/b2d6447636ba11feb827691eab6c48bb5e49d2fa/grain/_src/python/data_loader.py#L92-L99), but it is not used.

@iindyk, given our discussion in #1069, I've used `close` rather than context managers to clean up resources. This achieves the clean up, but does not address the doc discrepancy in #936. I can add the context manager implementation but wanted to discuss first given the preference for `close` over context managers in #1069.

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1185.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->