### PR TITLE
Fix type annotations for `ArrayRecordDataSource`.

### DIFF
--- a/grain/_src/python/data_sources.py
+++ b/grain/_src/python/data_sources.py
@@ -46,6 +46,12 @@ if platform.system() == "Windows":
   class ARDataSource:
     def __init__(self, *args, **kwargs):
       raise RuntimeError("array_record isn't supported on Windows")
+
+    def __len__(self) -> int:
+      raise RuntimeError("array_record isn't supported on Windows")
+
+    def __getitem__(self, index: int) -> bytes:
+      raise RuntimeError("array_record isn't supported on Windows")
 else:
   from array_record.python.array_record_data_source import (
       ArrayRecordDataSource as ARDataSource,
@@ -111,8 +117,8 @@ class ArrayRecordDataSource(ARDataSource):
     _api_usage_counter.Increment("ArrayRecordDataSource")
 
   @dataset_stats.trace_input_pipeline(stage_category=dataset_stats.IPL_CAT_READ)
-  def __getitem__(self, record_key: SupportsIndex) -> bytes:
-    data = super().__getitem__(record_key)
+  def __getitem__(self, index: int) -> bytes:
+    data = super().__getitem__(index)
     _bytes_read_counter.IncrementBy(len(data), "ArrayRecordDataSource")
     return data
 


### PR DESCRIPTION
This PR fixes type annotations for `ArrayRecordDataSource`s. Currently, `ArrayRecordDataSource` does not conform to the `RandomAccessDataSource` protocol for two reasons:

1. The stub that indicates `ArrayRecordDataSource` is not supported on Windows is missing `__len__` and `__getitem__`.
2. The implementation uses `record_key: SupportsIndex` instead of `index: int` as the `__getitem__` argument. Renaming the argument is backwards-compatible because it is never accessed as a keyword argument in normal usage.

Here's an example.

```python
from grain import MapDataset
from grain.sources import ArrayRecordDataSource


ds = ArrayRecordDataSource([])
MapDataset.source(ds)
```

### Before

```bash
$ pyright playground/ards.py
/Users/till/git/grain/playground/ards.py
  /Users/till/git/grain/playground/ards.py:6:19 - error: Argument of type "ArrayRecordDataSource" cannot be assigned to parameter "source" of type "Sequence[T@source] | RandomAccessDataSource[T@source]" in function "source"
    Type "ArrayRecordDataSource" is not assignable to type "Sequence[T@source] | RandomAccessDataSource[T@source]"
      "ArrayRecordDataSource" is incompatible with protocol "RandomAccessDataSource[T@source]"
        "__len__" is not present
          "__getitem__" is an incompatible type
            Type "(record_key: SupportsIndex) -> bytes" is not assignable to type "(index: int) -> T@RandomAccessDataSource"
      "ArrayRecordDataSource" is not assignable to "Sequence[T@source]" (reportArgumentType)
1 error, 0 warnings, 0 informations
```

### After

```bash
$ pyright playground/ards.py
0 errors, 0 warnings, 0 informations
```

This is very basic, but I've ended up with `cast(Sequence, ds)` in several places.

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1190.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->