### PR TITLE
Call `start_prefetch` immediately at the end of restoring

### DIFF
--- a/grain/_src/python/checkpoint/handler.py
+++ b/grain/_src/python/checkpoint/handler.py
@@ -66,6 +66,7 @@ class CheckpointHandler:
     else:
       state = state.encode()
     item.set_state(state)
+    item.start_prefetch()
     return item
 
   # Required by interface but not supported by PyGrain checkpoints.


### PR DESCRIPTION
The grain checkpoint handler is usually used together with other handlers (typically the array handler) in orbax under a composite handler. It is better to call `start_prefetch` immediately after setting state.

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1211.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->