### PR TITLE
Add missing max_sequences_per_bin for packed inputs

### DIFF
--- a/grain/_src/python/experimental/example_packing/packing.py
+++ b/grain/_src/python/experimental/example_packing/packing.py
@@ -232,7 +232,10 @@ class PackAndBatchOperation(Generic[_T]):
       if not element_added_to_batch:
         yield self._cur_batch.get_packed_batch()  # Main yield
         self._cur_batch = _PackedBatch(
-            element.data, self.batch_size, self.length_struct
+            element.data,
+            self.batch_size,
+            self.length_struct,
+            self.max_sequences_per_bin,
         )
         self._cur_batch.try_add_to_batch(element)
 


### PR DESCRIPTION
This is to fix a small bug from the original PR https://github.com/google/grain/pull/1039. The original issue (https://github.com/google/grain/issues/1000) was to meant to allow the user to specify the maximum segments packet into a sequence.

However, the addition only added the `self.max_sequences_per_bin` argument to the first instance of `_PackedBatch`, but not the second instance. See code section https://github.com/google/grain/blob/v0.2.15/grain/_src/python/experimental/example_packing/packing.py#L219-L236. This PR adds the missing `self.max_sequences_per_bin`. 


<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1215.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->