### PR TITLE
Remove unrelated package installation instructions

### DIFF
--- a/docs/tutorials/data_sources/load_from_s3_tutorial.ipynb
+++ b/docs/tutorials/data_sources/load_from_s3_tutorial.ipynb
@@ -61,7 +61,6 @@
       },
       "outputs": [],
       "source": [
-        "!pip install aws configure\n",
         "!pip install awscli"
       ]
     },

--- a/docs/tutorials/data_sources/load_from_s3_tutorial.md
+++ b/docs/tutorials/data_sources/load_from_s3_tutorial.md
@@ -36,7 +36,6 @@ This document outlines how to read data from an Amazon S3 bucket and construct a
 <!-- #endregion -->
 
 ```python id="8fhEOwxcWlWf"
-!pip install aws configure
 !pip install awscli
 ```
 


### PR DESCRIPTION
I assume this was originally a copy paste error: the `awscli` package installed on the line below is needed to run the `aws configure` command, but the `aws` and `configure` PyPI packages are unrelated and unneeded.

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1230.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->