### PR TITLE
Handle unparsed worker profiling flag

### DIFF
--- a/grain/_src/core/profiler.py
+++ b/grain/_src/core/profiler.py
@@ -64,10 +64,12 @@ def is_worker_profiling_supported() -> bool:
 
 def is_worker_profiling_enabled() -> bool:
   """Returns whether worker profiling is enabled."""
-  return (
-      is_worker_profiling_supported()
-      and _GRAIN_ENABLE_MULTIPROCESS_WORKER_PROFILING.value
-  )
+  if not is_worker_profiling_supported():
+    return False
+  try:
+    return _GRAIN_ENABLE_MULTIPROCESS_WORKER_PROFILING.value
+  except flags.UnparsedFlagAccessError:
+    return _GRAIN_ENABLE_MULTIPROCESS_WORKER_PROFILING.default
 
 
 def get_framework() -> str:

--- a/grain/_src/core/profiler_test.py
+++ b/grain/_src/core/profiler_test.py
@@ -101,6 +101,15 @@ class ProfilerTest(absltest.TestCase):
         profiler.is_worker_profiling_supported(),
     )
 
+  def test_worker_profiling_enabled_before_flags_are_parsed(self):
+    flags_were_parsed = flags.FLAGS.is_parsed()
+    flags.FLAGS.unparse_flags()
+    try:
+      self.assertFalse(profiler.is_worker_profiling_enabled())
+    finally:
+      if flags_were_parsed:
+        flags.FLAGS.mark_as_parsed()
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Fixes #1355.

## Summary

- avoid reading the worker-profiling Abseil flag before flags have been parsed
- use the flag's default value in that state, consistent with Grain's config handling
- cover the JAX-enabled, unparsed-flags path with a regression test

## Rationale

When JAX enables subprocess profiling support, `is_worker_profiling_enabled()` reaches `FlagHolder.value`. Abseil raises `UnparsedFlagAccessError` there for ordinary scripts that do not use `absl.app`. Falling back to the declared default preserves existing behavior until flags are parsed while leaving parsed flag values unchanged.

## Test plan

- [x] Run the issue reproduction without `flags.FLAGS.mark_as_parsed()` and consume a batch successfully
- [x] Run `profiler_test.py` with JAX enabled (9 tests passed)
- [x] Revert only the source fix and confirm the new regression test fails with `UnparsedFlagAccessError`


<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1361.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->