### PR TITLE
Fix SharedMemoryArray.__del__ AttributeError during interpreter shutdown

### DIFF
--- a/grain/_src/python/ipc/shared_memory_array.py
+++ b/grain/_src/python/ipc/shared_memory_array.py
@@ -165,21 +165,30 @@ class SharedMemoryArray(np.ndarray):
     """Mark this object responsible for unlinking the shared memory."""
     self._unlink_on_del = True
 
-  def __del__(self) -> None:
-    # Ensure that this array is not a view before closing shared memory
-    if not isinstance(self.base, mmap.mmap):
+  def __del__(
+      self,
+      _mmap_type=mmap.mmap,
+      _shared_memory_type=shared_memory.SharedMemory,
+      _del_shm=_del_shm,
+  ) -> None:
+    # Ensure that this array is not a view before closing shared memory.
+    # The default arguments are bound at import time so that this method still
+    # works during interpreter shutdown, when module-level names (such as
+    # `mmap` and `shared_memory`) may have been set to None. See issue #398.
+    if not isinstance(self.base, _mmap_type):
       return
-    thread_pool = SharedMemoryArray._del_thread_pool
-    outstanding_del_requests = SharedMemoryArray._outstanding_del_requests
+    cls = type(self)
+    thread_pool = cls._del_thread_pool
+    outstanding_del_requests = cls._outstanding_del_requests
     shm = self.shm
-    assert isinstance(shm, shared_memory.SharedMemory)
+    assert isinstance(shm, _shared_memory_type)
     if thread_pool:
       assert outstanding_del_requests is not None
       # We use a semaphore to make sure that we don't accumulate too many
       # requests to close/unlink shared memory, which could lead to OOM errors.
       if outstanding_del_requests.acquire(blocking=False):
         thread_pool.apply_async(
-            SharedMemoryArray.close_shm_async, args=(shm, self._unlink_on_del)
+            cls.close_shm_async, args=(shm, self._unlink_on_del)
         )
       else:
         _del_shm(shm, unlink=self._unlink_on_del)

--- a/grain/_src/python/ipc/shared_memory_array_test.py
+++ b/grain/_src/python/ipc/shared_memory_array_test.py
@@ -142,6 +142,23 @@ class SharedMemoryArrayTest(parameterized.TestCase):
     with self.assertRaises(FileNotFoundError):
       _ = shared_memory.SharedMemory(name=metadata.name, create=False)
 
+  def test_del_after_module_globals_cleared(self):
+    # During interpreter shutdown, module-level names may be set to None.
+    # `__del__` must not depend on them, otherwise it raises a spurious
+    # AttributeError that clutters the shutdown logs. See issue #398.
+    SharedMemoryArray._disable_async_del()
+    data = np.array([[1, 2], [3, 4]], dtype=np.int32)
+    shm_array = SharedMemoryArray(data.shape, data.dtype)
+    shm_array.unlink_on_del()
+    metadata = shm_array.metadata
+    with mock.patch.object(shared_memory_array, "mmap", None):
+      with mock.patch.object(shared_memory_array, "shared_memory", None):
+        with mock.patch.object(shared_memory_array, "SharedMemoryArray", None):
+          with mock.patch.object(shared_memory_array, "_del_shm", None):
+            del shm_array
+    with self.assertRaises(FileNotFoundError):
+      _ = shared_memory.SharedMemory(name=metadata.name, create=False)
+
   def test_del_many_async(self):
     SharedMemoryArray._disable_async_del()
     SharedMemoryArray.enable_async_del(


### PR DESCRIPTION
## Problem

At interpreter shutdown, `SharedMemoryArray.__del__` can raise:

```
Exception ignored in: <function SharedMemoryArray.__del__ at ...>
  File ".../shared_memory_array.py", line 170, in __del__
AttributeError: 'NoneType' object has no attribute 'mmap'
```

This is reported in #398 and clutters shutdown logs in data pipelines that use shared memory (e.g. `BatchOperation._enable_shared_memory()`).

## Root cause

`__del__` referenced module-level names directly:

```python
def __del__(self):
    if not isinstance(self.base, mmap.mmap):   # mmap -> None at shutdown
        ...
```

During interpreter shutdown CPython clears module dicts, setting these globals to `None`. A `SharedMemoryArray` instance that outlives the module then hits `None.mmap` and raises.

## Fix

Bind the `mmap.mmap` and `shared_memory.SharedMemory` types and the `_del_shm` helper as default arguments (bound at import time, so they survive module teardown), and reach the class attributes via `type(self)` instead of the `SharedMemoryArray` global.

## Test

Added `test_del_after_module_globals_cleared`, which clears `mmap`, `shared_memory`, `SharedMemoryArray` and `_del_shm` on the module and verifies deletion still unlinks the shared memory block without raising.

<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1386.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->