### PR TITLE
[Agent Generated] Enable batched source reads for MapDataset.batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ changes. Best viewed [here](https://google-grain.readthedocs.io/en/latest/change
 ## Unreleased
 
 * New features:
+  * Added source batch pushdown for `MapDataset.batch` through the public
+    `SupportsBatchedReadRandomAccessDataSource` protocol.
   * Added `HFIterDataset` to wrap Hugging Face streaming datasets, supporting sharding, slicing (`set_slice`), and state checkpointing.
   * `MapDataset.slice` now accepts a `Sequence[int]` (including a
     `MapDataset[int]`) in addition to a `slice` object, enabling arbitrary index

--- a/docs/data_sources/protocol.rst
+++ b/docs/data_sources/protocol.rst
@@ -37,6 +37,24 @@ Data sources with random access need to implement the following protocol:
         but records can be any Python object.
       """
 
+Efficient batched reads
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Random-access sources can additionally implement
+``SupportsBatchedReadRandomAccessDataSource`` to retrieve a sequence of records
+in one call:
+
+.. code-block:: python
+
+  class SupportsBatchedReadRandomAccessDataSource(RandomAccessDataSource[T]):
+
+    def __getitems__(self, indices: Sequence[int]) -> Sequence[T]:
+      """Returns records in the same order as ``indices``."""
+
+The method must preserve the order and duplicates in ``indices``. Grain uses it
+when ``MapDataset.batch`` is applied before ``MapDataset.to_iter_dataset``.
+Sources that only implement ``__getitem__`` continue to use scalar reads.
+
 Supported RA formats
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -104,6 +122,9 @@ defined above. In addition, you need to pay attention to the following:
     upon unpickling.
 *   If used with ``DataLoader`` sources should implement ``__repr__``. This is
     needed for ``DataLoader`` checkpoint validation.
+*   If the storage system supports reading multiple indices efficiently,
+    implement ``SupportsBatchedReadRandomAccessDataSource`` and apply
+    ``MapDataset.batch`` before converting the pipeline to ``IterDataset``.
 
 
 File systems

--- a/docs/grain.sources.rst
+++ b/docs/grain.sources.rst
@@ -9,6 +9,9 @@ List of Members
 .. autoclass:: RandomAccessDataSource
    :special-members: __len__, __getitem__,
 
+.. autoclass:: SupportsBatchedReadRandomAccessDataSource
+   :special-members: __len__, __getitem__, __getitems__
+
 .. autoclass:: ArrayRecordDataSource
    :special-members: __init__, __len__, __getitem__
 

--- a/grain/_src/python/dataset/base.py
+++ b/grain/_src/python/dataset/base.py
@@ -119,10 +119,15 @@ class RandomAccessDataSource(Protocol[T]):
 class SupportsBatchedReadRandomAccessDataSource(
     RandomAccessDataSource[T], Protocol[T]
 ):
-  """Interface for sources that support efficient random access and batched reads."""
+  """Interface for random-access sources that support efficient batched reads.
 
-  def _getitems(self, indices: Sequence[int]) -> Sequence[T]:
-    """Returns the values for the given record_keys.
+  Implementations must return one record for each requested index, preserving
+  the order and duplicates in ``indices``. Grain uses this method when a
+  ``MapDataset`` is batched before conversion to an ``IterDataset``.
+  """
+
+  def __getitems__(self, indices: Sequence[int]) -> Sequence[T]:
+    """Returns records for ``indices`` in the same order.
 
     This method must be threadsafe and deterministic.
 

--- a/grain/_src/python/dataset/base_test.py
+++ b/grain/_src/python/dataset/base_test.py
@@ -14,6 +14,7 @@
 """Tests for base.py."""
 
 import platform
+from typing import Sequence
 from absl.testing import absltest
 from absl.testing import parameterized
 from grain._src.python import data_sources
@@ -52,6 +53,32 @@ class RandomAccessDataSourceTest(parameterized.TestCase):
 
     source = MyInMemorySource(["a", "b", "c"])
     self.assertIsInstance(source, base.RandomAccessDataSource)
+
+  def test_batched_read_protocol(self):
+    class MyBatchedSource:
+
+      def __init__(self, data: list[str]):
+        self._data = data
+
+      def __len__(self) -> int:
+        return len(self._data)
+
+      def __getitem__(self, index: int) -> str:
+        return self._data[index]
+
+      def __getitems__(self, indices: Sequence[int]) -> Sequence[str]:
+        return [self._data[index] for index in indices]
+
+    source = MyBatchedSource(["a", "b", "c"])
+    self.assertIsInstance(
+        source, base.SupportsBatchedReadRandomAccessDataSource
+    )
+
+  def test_array_record_supports_batched_read_protocol(self):
+    self.assertIsInstance(
+        data_sources.ArrayRecordDataSource,
+        base.SupportsBatchedReadRandomAccessDataSource,
+    )
 
 
 class DatasetSelectionMapTest(parameterized.TestCase):

--- a/grain/_src/python/dataset/transformations/batch.py
+++ b/grain/_src/python/dataset/transformations/batch.py
@@ -37,11 +37,6 @@ T = TypeVar("T")
 S = TypeVar("S")
 
 
-@functools.cache
-def _is_batch_map_pushdown_experiment_enabled() -> bool:
-  return False
-
-
 def _is_parallel_batch_experiment_enabled():
   return False
 
@@ -437,11 +432,8 @@ class BatchMapDataset(dataset.MapDataset[T]):
     self._update_length()
 
   def _get_parent_items(self, items):
-    # Leverage batch pushdown API to retrieve multiple items at once if the
-    # experiment is enabled.
-    if _is_batch_map_pushdown_experiment_enabled():
-      return self._parent._getitems(list(items))  # pylint: disable=protected-access
-    return [self._parent[i] for i in items]
+    """Retrieves parent elements through the batch-aware dataset path."""
+    return self._parent._getitems(list(items))  # pylint: disable=protected-access
 
   def __len__(self):
     return self._length

--- a/grain/_src/python/dataset/transformations/batch_test.py
+++ b/grain/_src/python/dataset/transformations/batch_test.py
@@ -77,6 +77,33 @@ class CustomBatchFn(batch.BatchFn):
     }
 
 
+class _CountingRandomAccessSource:
+  """Random-access source that records scalar reads."""
+
+  def __init__(self, values: Sequence[int]):
+    self._values = values
+    self.scalar_reads = []
+
+  def __len__(self) -> int:
+    return len(self._values)
+
+  def __getitem__(self, index: int) -> int:
+    self.scalar_reads.append(index)
+    return self._values[index]
+
+
+class _CountingBatchedReadSource(_CountingRandomAccessSource):
+  """Random-access source that records batched reads."""
+
+  def __init__(self, values: Sequence[int]):
+    super().__init__(values)
+    self.batched_reads = []
+
+  def __getitems__(self, indices: Sequence[int]) -> Sequence[int]:
+    self.batched_reads.append(tuple(indices))
+    return [self._values[index] for index in indices]
+
+
 class MakeBatchTest(absltest.TestCase):
 
   def test_batch_zero_values_error(self):
@@ -286,6 +313,44 @@ class BatchMapDatasetTest(parameterized.TestCase):
     super().tearDown()
     importlib.reload(batch.tree_lib)
     importlib.reload(batch)
+
+  def test_pushes_batches_to_source(self):
+    data_source = _CountingBatchedReadSource(list(range(10)))
+    ds = source.SourceMapDataset(data_source)
+    ds = batch.BatchMapDataset(ds, batch_size=4, batch_fn=list)
+
+    self.assertEqual(list(ds), [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]])
+    self.assertEmpty(data_source.scalar_reads)
+    self.assertCountEqual(
+        data_source.batched_reads,
+        [(0, 1, 2, 3), (4, 5, 6, 7), (8, 9)],
+    )
+
+  def test_scalar_source_fallback(self):
+    data_source = _CountingRandomAccessSource(list(range(5)))
+    ds = source.SourceMapDataset(data_source)
+    ds = batch.BatchMapDataset(ds, batch_size=3, batch_fn=list)
+
+    self.assertEqual(list(ds), [[0, 1, 2], [3, 4]])
+    self.assertEqual(data_source.scalar_reads, [0, 1, 2, 3, 4])
+
+  def test_pushdown_through_map_transformations(self):
+    def make_pipeline(ds):
+      return (
+          ds.shuffle(seed=42)
+          .map(lambda value: value * 2)
+          .repeat(2)
+          .batch(batch_size=4, batch_fn=list)
+      )
+
+    values = list(range(7))
+    expected = list(make_pipeline(source.SourceMapDataset(values)))  # pyrefly: ignore[bad-argument-type]
+    data_source = _CountingBatchedReadSource(values)
+    actual = list(make_pipeline(source.SourceMapDataset(data_source)))
+
+    self.assertEqual(actual, expected)
+    self.assertEmpty(data_source.scalar_reads)
+    self.assertNotEmpty(data_source.batched_reads)
 
   @parameterized.named_parameters(
       dict(

--- a/grain/_src/python/dataset/transformations/source.py
+++ b/grain/_src/python/dataset/transformations/source.py
@@ -105,7 +105,7 @@ class SourceMapDataset(dataset.MapDataset):
       return super()._getitems(indices)
     with self._stats.record_self_time(num_elements=len(indices)):
       start_time = time.perf_counter_ns()
-      elements = self._source._getitems(  # pylint: disable=protected-access
+      elements = self._source.__getitems__(
           [self._index_mod_len(index) for index in indices]
       )
       stop_time = time.perf_counter_ns()

--- a/grain/_src/python/dataset/transformations/source_test.py
+++ b/grain/_src/python/dataset/transformations/source_test.py
@@ -37,7 +37,7 @@ class _MyRandomAccessDataSource:
 
 class _MySupportsBatchedReadRandomAccessDataSource(_MyRandomAccessDataSource):
 
-  def _getitems(self, indices: Sequence[int]):
+  def __getitems__(self, indices: Sequence[int]):
     return [self._data[i] for i in indices]
 
 
@@ -134,6 +134,13 @@ class SourceMapDatasetTest(absltest.TestCase):
         indices_to_read
     )
     self.assertEqual(expected_data, actual_data)
+
+  def test_lazy_dataset_source_batched_read_preserves_duplicates(self):
+    indices_to_read = [3, 1, 3, 0]
+    actual_data = self._batched_read_lazy_dataset_source._getitems(
+        indices_to_read
+    )
+    self.assertEqual(actual_data, [4, 2, 4, 1])
 
   def test_lazy_dataset_source_batched_read_get_random_modulo(self):
     len_data_source = len(self._batched_read_lazy_dataset_source)

--- a/grain/python/__init__.py
+++ b/grain/python/__init__.py
@@ -58,6 +58,7 @@ from grain._src.python.data_sources import (
 from grain._src.python.dataset.base import (
     DatasetSelectionMap,
     RandomAccessDataSource,
+    SupportsBatchedReadRandomAccessDataSource,
 )
 from grain._src.python.dataset.dataset import (
     MapDataset,

--- a/grain/sources.py
+++ b/grain/sources.py
@@ -28,4 +28,7 @@ from grain._src.python.data_sources import (
     SharedMemoryDataSource,
     RangeDataSource,
 )
-from grain._src.python.dataset.base import RandomAccessDataSource
+from grain._src.python.dataset.base import (
+    RandomAccessDataSource,
+    SupportsBatchedReadRandomAccessDataSource,
+)


### PR DESCRIPTION
## Summary

- publish `SupportsBatchedReadRandomAccessDataSource` with a public `__getitems__` contract
- enable the existing `MapDataset.batch` source-pushdown path
- preserve scalar fallback for sources that only implement `__getitem__`
- document ordering, duplicate-index, and pipeline-placement requirements

ArrayRecord already implements `__getitems__`, so this lets `MapDataset.batch` retrieve a complete index group in one source call when batching happens before conversion to `IterDataset`.

Related to #1164.

## Validation

- 117 focused dataset/source/batch tests passed
- public API and built-in ArrayRecord protocol smoke test passed
- pre-commit hooks passed
- broader local suite: 4,692 passed, 79 skipped, 3 xfailed; three unrelated local-runner failures remain in multiprocessing patching and timing-sensitive execution-summary logging

The focused tests cover batched calls without scalar reads, scalar fallback, partial batches, request order and duplicate indices, and propagation through shuffle/map/repeat.


<!-- readthedocs-preview google-grain start -->
----
📚 Documentation preview 📚: https://google-grain--1388.org.readthedocs.build/

<!-- readthedocs-preview google-grain end -->